### PR TITLE
Make external services configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,11 @@
 
 # Server Configuration
 NODE_ENV=production
-SERVER_URL=https://crm.4ow4.com
+SERVER_URL=http://localhost:3000
+
+# Base URLs for external services
+COMPANIES_BASE_URL=https://twenty-companies.com
+ICONS_BASE_URL=https://twenty-icons.com
 
 # Database Configuration
 PG_DATABASE_USER=postgres
@@ -28,12 +32,12 @@ STORAGE_TYPE=local
 AUTH_GOOGLE_ENABLED=false
 # AUTH_GOOGLE_CLIENT_ID=your_google_client_id
 # AUTH_GOOGLE_CLIENT_SECRET=your_google_client_secret
-# AUTH_GOOGLE_CALLBACK_URL=https://crm.4ow4.com/auth/google/redirect
+# AUTH_GOOGLE_CALLBACK_URL=http://localhost:3000/auth/google/redirect
 
 # Email Configuration
-EMAIL_FROM_ADDRESS=noreply@crm.4ow4.com
+EMAIL_FROM_ADDRESS=noreply@localhost
 EMAIL_FROM_NAME=ProPods CRM
-EMAIL_SYSTEM_ADDRESS=system@crm.4ow4.com
+EMAIL_SYSTEM_ADDRESS=system@localhost
 EMAIL_DRIVER=logger
 # For SMTP, configure these:
 # EMAIL_DRIVER=smtp

--- a/packages/twenty-server/src/engine/core-modules/auth/services/sign-in-up.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/services/sign-in-up.service.ts
@@ -2,7 +2,7 @@ import { HttpService } from '@nestjs/axios';
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 
-import { TWENTY_ICONS_BASE_URL } from 'twenty-shared/constants';
+import { ICONS_BASE_URL } from 'twenty-shared/constants';
 import { WorkspaceActivationStatus } from 'twenty-shared/workspace';
 import { Repository } from 'typeorm';
 import { v4 } from 'uuid';
@@ -326,7 +326,7 @@ export class SignInUpService {
       }
     }
 
-    const logoUrl = `${TWENTY_ICONS_BASE_URL}/${getDomainNameByEmail(email)}`;
+    const logoUrl = `${ICONS_BASE_URL}/${getDomainNameByEmail(email)}`;
     const isLogoUrlValid = async () => {
       try {
         return (

--- a/packages/twenty-server/src/modules/contact-creation-manager/services/create-company.service.ts
+++ b/packages/twenty-server/src/modules/contact-creation-manager/services/create-company.service.ts
@@ -3,7 +3,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 
 import axios, { AxiosInstance } from 'axios';
 import uniqBy from 'lodash.uniqby';
-import { TWENTY_COMPANIES_BASE_URL } from 'twenty-shared/constants';
+import { COMPANIES_BASE_URL } from 'twenty-shared/constants';
 import { ConnectedAccountProvider } from 'twenty-shared/types';
 import { DeepPartial, ILike, Repository } from 'typeorm';
 
@@ -40,7 +40,7 @@ export class CreateCompanyService {
     private readonly objectMetadataRepository: Repository<ObjectMetadataEntity>,
   ) {
     this.httpService = axios.create({
-      baseURL: TWENTY_COMPANIES_BASE_URL,
+      baseURL: COMPANIES_BASE_URL,
     });
   }
 

--- a/packages/twenty-shared/src/constants/TwentyCompaniesBaseUrl.ts
+++ b/packages/twenty-shared/src/constants/TwentyCompaniesBaseUrl.ts
@@ -1,1 +1,2 @@
-export const TWENTY_COMPANIES_BASE_URL = 'https://twenty-companies.com';
+export const COMPANIES_BASE_URL =
+  process.env.COMPANIES_BASE_URL ?? 'https://twenty-companies.com';

--- a/packages/twenty-shared/src/constants/TwentyIconsBaseUrl.ts
+++ b/packages/twenty-shared/src/constants/TwentyIconsBaseUrl.ts
@@ -1,1 +1,2 @@
-export const TWENTY_ICONS_BASE_URL = 'https://twenty-icons.com';
+export const ICONS_BASE_URL =
+  process.env.ICONS_BASE_URL ?? 'https://twenty-icons.com';

--- a/packages/twenty-shared/src/constants/index.ts
+++ b/packages/twenty-shared/src/constants/index.ts
@@ -13,5 +13,5 @@ export { FIELD_RESTRICTED_ADDITIONAL_PERMISSIONS_REQUIRED } from './FieldRestric
 export { PermissionsOnAllObjectRecords } from './PermissionsOnAllObjectRecords';
 export { QUERY_MAX_RECORDS } from './QueryMaxRecords';
 export { STANDARD_OBJECT_RECORDS_UNDER_OBJECT_RECORDS_PERMISSIONS } from './StandardObjectRecordsUnderObjectRecordsPermissions';
-export { TWENTY_COMPANIES_BASE_URL } from './TwentyCompaniesBaseUrl';
-export { TWENTY_ICONS_BASE_URL } from './TwentyIconsBaseUrl';
+export { COMPANIES_BASE_URL } from './TwentyCompaniesBaseUrl';
+export { ICONS_BASE_URL } from './TwentyIconsBaseUrl';


### PR DESCRIPTION
## Summary
- use COMPANIES_BASE_URL and ICONS_BASE_URL env vars
- update server services to use new constants
- default SERVER_URL to localhost
- sanitize `.env.example` to be local-first

## Testing
- `yarn --version` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_6851301b736c832b9c5ed4830518f510